### PR TITLE
Add node v10 to publishing stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,10 +73,10 @@ jobs:
     - stage: publish
       name: "Publish the plugin"
       if: (branch = master) AND (type = push)
-  #     os: linux
-  #     language: node_js
-  #     node_js:
-  #       - "10"
+      os: linux
+      language: node_js
+      node_js:
+        - "10"
   #     env:
   #       - JOBNAME=AMD6
       before_install:


### PR DESCRIPTION
Build failed because Travis is defaulting to node 8:  https://travis-ci.com/open-cluster-management/search-kui-plugin/jobs/286920338#L671