### PR TITLE
fix: fix sidecar related:resource styling

### DIFF
--- a/src/src-web/styles/index.scss
+++ b/src/src-web/styles/index.scss
@@ -902,7 +902,7 @@ span{
       &.bx--tile--clickable{
         margin-top: 5%;
         float: left;
-        width: 30%;
+        width: 25%;
         height: 100px;
         border: none;
 


### PR DESCRIPTION
re [#1672](https://github.com/open-cluster-management/backlog/issues/1672)

Before:
<kbd>![Screen Shot 2020-04-17 at 2 50 25 PM](https://user-images.githubusercontent.com/10394596/79603716-da1fa200-80ba-11ea-95c3-fe2383586214.png)</kbd>

<kbd>![Screen Shot 2020-04-17 at 2 49 03 PM](https://user-images.githubusercontent.com/10394596/79603748-e73c9100-80ba-11ea-9620-2836ae9de0f3.png)</kbd>

Also, updated tile width to allow more columns.